### PR TITLE
feat(Pixelgrid): Ajout du lock ether sur un pixel

### DIFF
--- a/contract/PixelGrid.sol
+++ b/contract/PixelGrid.sol
@@ -4,8 +4,12 @@ pragma solidity ^0.8.0;
 contract PixelGrid {
     uint256 public constant SIZE = 50;
 
+    // Track ETH owed to people who were outbid
+    mapping(address => uint256) public pendingRefunds;
+
     struct Pixel {
-        address author;
+        address topLocker;
+        uint256 highestAmountLocked;
         string color;
     }
 
@@ -13,11 +17,39 @@ contract PixelGrid {
 
     event PixelChanged(uint256 id, address author, string color);
 
+    function getPixel(uint256 _x, uint256 _y) public view returns (Pixel memory) {
+        return grid[_x + (_y * SIZE)];
+    }
+
     function setPixel(uint256 _x, uint256 _y, string memory _color) public {
         require(_x < SIZE && _y < SIZE, "Hors limites");
         uint256 id = _x + (_y * SIZE);
-        grid[id] = Pixel(msg.sender, _color);
+        Pixel storage pixel = grid[id];
+        require(pixel.topLocker == msg.sender, "Vous devez etre le proprietaire du pixel pour le modifier");
+        pixel.color = _color;
+
         emit PixelChanged(id, msg.sender, _color);
+    }
+
+    function ownPixel(uint256 _x, uint256 _y) public payable {
+        require(_x < SIZE && _y < SIZE, "Hors limites");
+        uint256 id = _x + (_y * SIZE);
+        Pixel storage pixel = grid[id];
+
+        // Si le pixel est déjà possédé, le nouveau montant doit être plus élevé
+        require(msg.value > pixel.highestAmountLocked, "Doit etre plus eleve que le montant actuel");
+
+        // Si quelqu'un était déjà le propriétaire, ajouter son montant à ses remboursements
+        if (pixel.highestAmountLocked > 0) {
+            pendingRefunds[pixel.topLocker] += pixel.highestAmountLocked;
+        }
+
+        // Mettre à jour le pixel avec le nouveau propriétaire et montant
+        pixel.topLocker = msg.sender;
+        pixel.highestAmountLocked = msg.value;
+        pixel.color = "red";
+
+        emit PixelChanged(id, msg.sender, "red");
     }
 
     function getFullGrid() public view returns (Pixel[] memory) {
@@ -26,5 +58,18 @@ contract PixelGrid {
             allPixels[i] = grid[i];
         }
         return allPixels;
+    }
+
+    // 2. Function for outbid users to get their ETH back (The "Pull" pattern)
+    function claimRefund() public {
+        uint256 refundAmount = pendingRefunds[msg.sender];
+        require(refundAmount > 0, "You have no funds to refund");
+
+        // ALWAYS zero out the balance BEFORE sending the ETH (prevents reentrancy)
+        pendingRefunds[msg.sender] = 0;
+
+        // Send the ETH
+        (bool success, ) = msg.sender.call{value: refundAmount}("");
+        require(success, "ETH transfer failed");
     }
 }

--- a/ganache.nix
+++ b/ganache.nix
@@ -1,0 +1,17 @@
+{
+  pkgs ? import <nixpkgs> { },
+}:
+
+pkgs.appimageTools.wrapType2 {
+  pname = "ganache";
+  version = "2.7.1";
+
+  # Ensure this points to the exact name of your downloaded AppImage
+  src = ./ganache-2.7.1-linux-x86_64.AppImage;
+
+  # Inject the missing library into the AppImage's environment
+  extraPkgs =
+    pkgs: with pkgs; [
+      xorg.libxshmfence
+    ];
+}


### PR DESCRIPTION
This pull request introduces significant enhancements to the `PixelGrid` smart contract, adding pixel ownership and bidding mechanics, as well as secure ETH refund handling for outbid users. Additionally, it adds a Nix configuration for running Ganache as an AppImage with required dependencies.

**Pixel ownership and bidding enhancements:**

* Added pixel ownership via the `ownPixel` function, allowing users to bid for pixels by locking ETH; the highest bidder becomes the owner, and outbid users' ETH is tracked for refunds. (`contract/PixelGrid.sol`)
* Introduced the `pendingRefunds` mapping and `claimRefund` function, enabling outbid users to securely withdraw their ETH using the "Pull" pattern to prevent reentrancy attacks. (`contract/PixelGrid.sol`)
* Updated the `Pixel` struct to include `topLocker` and `highestAmountLocked` fields, replacing `author` to support the new ownership and bidding logic. (`contract/PixelGrid.sol`)

**API additions and changes:**

* Added `getPixel` function for retrieving individual pixel details, and updated `setPixel` to require ownership before modifying a pixel's color. (`contract/PixelGrid.sol`)

**Development environment setup:**

* Added `ganache.nix` file to wrap the Ganache AppImage with Nix, ensuring the required `libxshmfence` library is available for proper execution. (`ganache.nix`)